### PR TITLE
Show usage and exit on error

### DIFF
--- a/src/gistit.c
+++ b/src/gistit.c
@@ -205,7 +205,9 @@ int main(int argc, char *argv[])
 			continue;
 		}
 
-		printf("Warning: Unknown parameter: %s\n", argv[i]);
+		printf("Error: Unknown parameter: %s\n", argv[i]);
+                usage();
+                exit(EXIT_FAILURE);
 	}
 
 	// Creating the JSON list of files


### PR DESCRIPTION
Why:

* It could be dangerous to just create an anonymous gist when the usage is wrong

From my own experience today: I tried to create a secret gist, but remembered wrong and did this: `gistit --priv a_file_with_some_secrets.txt` (notice wrong usage of `--priv`) The result was an open gist revealing the file that should have been private as an open anonymous gist. In addition when the gist is anonymous, there is no way to delete it other than contacting github support. IMHO it would be better to exit with an error when the usage is wrong and to output the usage help text explaining the valid usage. 